### PR TITLE
Switch to plain ES6 w/o Babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["env"],
-  "plugins": ["transform-runtime"]
-}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,24 +1,5 @@
 module.exports = {
   env: { node: true },
   extends: 'eslint-config-brigade/node',
-  parserOptions: { ecmaVersion: 9 },
-  rules: {
-    'no-unused-vars': [2, { argsIgnorePattern: '^_' }],
-    'max-len': [2, {
-      code: 100,
-      ignoreComments: true,
-      ignoreUrls: true,
-      ignoreTemplateLiterals: true,
-      ignoreStrings: true,
-    }],
-    'func-style': [2, 'expression', { allowArrowFunctions: true }],
-    'import/prefer-default-export': 2,
-    'import/named': 2,
-    'import/newline-after-import': 2,
-    'import/no-duplicates': 2,
-    'import/no-mutable-exports': 2,
-    'import/imports-first': 2,
-    'max-nested-callbacks': [2, 6],
-    'comma-dangle': [2, 'always-multiline'],
-  },
+  parserOptions: { ecmaVersion: 6 },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
 package-lock.json
 node_modules/
-
-dist/

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,4 @@
-src
 test
 node_modules
-.babelrc
 .eslintignore
 .eslintrc.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: node_js
 node_js:
   - 'node'
   - '8'
-  - '7'
   - '6'
 script:
   - npm run lint
   - npm test
-  - npm run build

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "@brigade/pooled-thrift-client",
   "version": "1.0.3",
   "description": "A Thrift client utilising a pool of service connections and improved error handling/recovery",
-  "main": "dist/index.js",
+  "main": "src/index.js",
+  "engines": {
+    "node": ">= 6"
+  },
   "scripts": {
-    "build": "babel src -d dist",
     "lint": "eslint .",
-    "prepublish": "npm run build",
     "test": "jasmine"
   },
   "repository": {
@@ -25,14 +26,10 @@
   },
   "homepage": "https://github.com/brigade/pooled-thrift-client#readme",
   "dependencies": {
-    "babel-runtime": "^6.26.0",
     "generic-pool": "^3.4.0",
     "thrift": "^0.11.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.6.1",
     "eslint": "^4.13.1",
     "eslint-config-brigade": "^7.0.0",
     "jasmine": "^2.9.0"

--- a/spec/indexSpec.js
+++ b/spec/indexSpec.js
@@ -1,4 +1,4 @@
-import thriftClient from '../src';
+const thriftClient = require('../src');
 
 describe('pooledThriftClient', () => {
   beforeEach(() => {

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -4,8 +4,7 @@
     "**/*[sS]pec.js"
   ],
   "helpers": [
-    "supprt/helpers/**/*.js",
-     "../node_modules/babel-core/register.js"
+    "supprt/helpers/**/*.js"
   ],
   "stopSpecOnExpectationFailure": false,
   "random": false

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,26 +1,30 @@
 /* Error types */
 
-export const AcquisitionTimeoutError = class extends Error {
+// Exceeded timeout for checking a connection out of the pool
+class AcquisitionTimeoutError extends Error {
   constructor(message, metadata = {}) {
     super(`Thrift pool connection acquisition timeout: ${message}`, metadata);
     this.name = 'AcquisitionTimeoutError';
     Error.captureStackTrace(this, AcquisitionTimeoutError);
   }
-};
+}
 
-export const ConnectionTimeoutError = class extends Error {
+// Exceeded timeout for a single request
+class ConnectionTimeoutError extends Error {
   constructor() {
     super('Thrift connection timeout');
     this.name = 'ConnectionTimeoutError';
     Error.captureStackTrace(this, ConnectionTimeoutError);
   }
-};
+}
 
-export const ConnectionClosedError = class extends Error {
+// Connection was closed remotely while in use
+class ConnectionClosedError extends Error {
   constructor() {
     super('Thrift connection closed');
     this.name = 'ConnectionClosedError';
     Error.captureStackTrace(this, ConnectionClosedError);
   }
-};
+}
 
+module.exports = { AcquisitionTimeoutError, ConnectionTimeoutError, ConnectionClosedError };


### PR DESCRIPTION
Something about the way Babel’s set up in this project produces a
non-working library that never actually pools, instead creating a new
connection each time a request is made. This code is tested and known
to work on its own within an ES6 project, so presumably transpiling it
down to basic ES2015 breaks something (either here or with its
generic-pool bindings). Since this library is designed for Node and
doesn’t use any particularly fancy features, strip out all the magic
(import, async/await) and make it a pure ES6 library, usable by any
Node version 6 and higher.