### PR TITLE
Enable oneway function in Thrift, tune log, default pool size, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A node Thrift client utilising a pool of service connections and improved error 
 - builtin retry support using upstream Thrift code
 - faster detection and pruning of dead connections
 - async/await compatibility and other niceties
+- enabled oneway function
+- enable trace log with debug mod
 
 ## Example usage
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
   },
   "homepage": "https://github.com/brigade/pooled-thrift-client#readme",
   "dependencies": {
-    "generic-pool": "^3.4.0",
-    "thrift": "^0.11.0"
+    "debug": "^4.1.1",
+    "generic-pool": "^3.7.1",
+    "thrift": "^0.12.0"
   },
   "devDependencies": {
     "eslint": "^4.13.1",


### PR DESCRIPTION
Sorry, my stupid editor has formatted the codes, the changes are:

* add debug module and `role` in thriftOption to print trace log
* upgrade generic pool version to latest
* compatiable with thrift 0.12.0
* tune default pool size
* enable oneway function for Thrift DSL